### PR TITLE
feat: store the profile image url of logged in user

### DIFF
--- a/src/firebase/players.ts
+++ b/src/firebase/players.ts
@@ -18,6 +18,7 @@ const playersCollection = collection(firestore, "players");
 
 interface Props {
   uid: string;
+  profileUrl: string;
   headTag: string;
   modelColor: RobotColor;
   modelType: RobotModelType;
@@ -28,6 +29,7 @@ interface Props {
 
 const createPlayer = async ({
   uid,
+  profileUrl,
   headTag,
   modelColor,
   modelType,
@@ -38,6 +40,7 @@ const createPlayer = async ({
   const _player = doc(firestore, `players/${uid}`);
   const playerData = {
     uid,
+    profileUrl,
     headTag,
     modelColor,
     modelType,

--- a/src/pages/name-your-robot.tsx
+++ b/src/pages/name-your-robot.tsx
@@ -77,6 +77,7 @@ export default function NameYourRobot() {
         // firebase 데이터베이스에 새로운 플레이어 생성 요청
         await createPlayer({
           uid: user.uid,
+          profileUrl: user.image,
           headTag: inputValue,
           modelColor: player.color,
           modelType: player.model,


### PR DESCRIPTION
## Updates
- firebase 데이터베이스 `players` 컬렉션의 문서 필드로 카카오 로그인 사용자의 `profileUrl` 추가
![image](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/6097fde3-138e-40f4-bfd8-cd08e17a1f96)
