### PR TITLE
feat: display score in real-time

### DIFF
--- a/src/components/organisms/ControlPanel/index.tsx
+++ b/src/components/organisms/ControlPanel/index.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import _ from "lodash";
 import { toast } from "react-toastify";
 
+import useGameActions from "@/hooks/useGameActions";
 import usePlayer from "@/hooks/usePlayer";
 import useUser from "@/hooks/useUser";
 import { REMOTE_CONTROL_API_ACCESS_TYPE } from "@/types";
@@ -13,6 +14,7 @@ import { FireButton, JumpButton, MoveLeftButton, MoveRightButton, Panel } from "
 export default function ControlPanel() {
   const user = useUser();
   const player = usePlayer();
+  const { assignPlayer } = useGameActions();
 
   const moveForward = async (val: 0 | 1 | -1) => {
     if (_.isNil(player)) return;
@@ -35,6 +37,7 @@ export default function ControlPanel() {
       }
     }
   };
+
   const handleForward = async (e: MouseEvent, sec: number) => {
     e.preventDefault();
 
@@ -44,6 +47,7 @@ export default function ControlPanel() {
       await moveForward(0);
     }, 1000 * sec);
   };
+
   const handleBackward = async (e: MouseEvent, sec: number) => {
     e.preventDefault();
 
@@ -62,16 +66,32 @@ export default function ControlPanel() {
       functionName: "OnJump",
     });
   };
-  const onFire = async () => {
+
+  const onFire = async () =>
     await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
       objectPath: player.objectPath,
       functionName: "OnFire",
     });
-  };
-  const handleFire = async (e: MouseEvent) => {
+
+  const getScore = async () =>
+    await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
+      objectPath: player.objectPath,
+      functionName: "GetPlayerScore",
+    });
+
+  const handleFire = (e: MouseEvent) => {
     e.preventDefault();
 
-    await onFire();
+    onFire().then(() => {
+      setTimeout(() => {
+        getScore().then((res) => {
+          assignPlayer({
+            ...player,
+            score: res.data.PlayerScore,
+          });
+        });
+      }, 500);
+    });
   };
 
   return (

--- a/src/components/organisms/ControlPanel/index.tsx
+++ b/src/components/organisms/ControlPanel/index.tsx
@@ -83,11 +83,13 @@ export default function ControlPanel() {
     e.preventDefault();
 
     onFire().then(() => {
+      // 발사 이후 점수가 업데이트되기까지 약간의 지연시간이 소요되므로,
+      // 0.5초 뒤에 점수 요청 및 전역 상태 업데이트
       setTimeout(() => {
         getScore().then((res) => {
           assignPlayer({
             ...player,
-            score: res.data.PlayerScore,
+            thisRoundScore: res.data.PlayerScore,
           });
         });
       }, 500);

--- a/src/components/organisms/Timer/styles.ts
+++ b/src/components/organisms/Timer/styles.ts
@@ -1,5 +1,0 @@
-import { styled } from "@mui/material/styles";
-
-export const Container = styled("div")`
-  font-size: 32px;
-`;

--- a/src/firebase/players.ts
+++ b/src/firebase/players.ts
@@ -23,7 +23,7 @@ interface Props {
   modelColor: RobotColor;
   modelType: RobotModelType;
   username: string;
-  score: number;
+  score: number[]; // 지금까지 출동해서 받은 점수들의 배열
   playedNum: number;
 }
 
@@ -73,7 +73,7 @@ const updatePlayer = async ({
 }: {
   documentId: string;
   updated: {
-    score?: number;
+    score?: number[];
     playedNum?: number;
   };
 }) => {

--- a/src/pages/[clientId]/index.tsx
+++ b/src/pages/[clientId]/index.tsx
@@ -48,8 +48,9 @@ export default function HomePage() {
             headTag,
             model: modelType,
             color: modelColor,
-            score,
-            playedNum,
+            thisRoundScore: 0,
+            allRoundScore: score ?? [],
+            playedNum: playedNum ?? 0,
           });
         }
         // 사용자가 입장할 섹션을 선택하는 페이지로 이동

--- a/src/pages/going-to-hangar.tsx
+++ b/src/pages/going-to-hangar.tsx
@@ -5,33 +5,69 @@ import _ from "lodash";
 import { toast } from "react-toastify";
 
 import { updatePlayer } from "@/firebase/players";
+import useGameActions from "@/hooks/useGameActions";
+import useGameStatus from "@/hooks/useGameRound";
 import usePlayer from "@/hooks/usePlayer";
+import useUser from "@/hooks/useUser";
 import { Page } from "@/types";
 
 import { Container, LoadingMessage } from "@/styles/going-to-hangar";
 
 export default function GoingToHangar() {
   const router = useRouter();
+  const user = useUser();
   const player = usePlayer();
+  const gameRound = useGameStatus();
+  const { updateGameRound, assignPlayer } = useGameActions();
 
   useEffect(() => {
     if (_.isNil(player)) return;
-    if (!player?.objectPath) return;
+
+    let objectPath;
+    if (!player?.objectPath) {
+      axios
+        .put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
+          objectPath: gameRound.gameModeBaseObjectPath,
+          functionName: "BindingCharacter",
+          parameters: {
+            Model: player.model,
+            Color: player.color,
+            Name: player.headTag,
+            UID: user.uid,
+          },
+          generateTransaction: true,
+        })
+        .then((res) => {
+          const createdCharacterInfo = res.data;
+          objectPath = createdCharacterInfo.CharacterPath;
+        });
+    }
 
     try {
       // 플레이어를 화면 중앙에 위치하게 하기
       axios
         .put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
-          objectPath: player.objectPath,
+          objectPath: player.objectPath || objectPath,
           functionName: "SetPlayerLocation",
           generateTransaction: true,
         })
         .then(() => {
+          // firebase 데이터베이스에 출동횟수 + 1한 값으로 업데이트
           updatePlayer({
             documentId: player.uid,
             updated: {
               playedNum: player.playedNum ? player.playedNum + 1 : 1,
             },
+          });
+          // 전역 상태에 출동회수 +1한 값으로 업데이트
+          assignPlayer({
+            ...player,
+            playedNum: player.playedNum ? player.playedNum + 1 : 1,
+          });
+          // 게임 진행 여부 true로 업데이트
+          updateGameRound({
+            ...gameRound,
+            isGameInProgress: true,
           });
           router.push(Page.PLAY);
         });

--- a/src/pages/name-your-robot.tsx
+++ b/src/pages/name-your-robot.tsx
@@ -79,7 +79,7 @@ export default function NameYourRobot() {
             modelColor: player.color,
             modelType: player.model,
             username: user.displayName,
-            score: player.score ?? 0,
+            score: player.allRoundScore ?? [],
             playedNum: player.playedNum ?? 0,
           });
 

--- a/src/pages/play.tsx
+++ b/src/pages/play.tsx
@@ -14,7 +14,7 @@ export default function PlayGame() {
       <PlayerInfoBox>
         <Image src="/assets/images/star.svg" alt="star" width={17} height={17} />
         <PlayerName>{player.headTag}</PlayerName>
-        <Score>{player.score || 4560}</Score>
+        <Score>{player.score}</Score>
       </PlayerInfoBox>
       <ControlPanel />
       <GameStatusBar />

--- a/src/pages/play.tsx
+++ b/src/pages/play.tsx
@@ -14,7 +14,7 @@ export default function PlayGame() {
       <PlayerInfoBox>
         <Image src="/assets/images/star.svg" alt="star" width={17} height={17} />
         <PlayerName>{player.headTag}</PlayerName>
-        <Score>{player.score}</Score>
+        <Score>{player.thisRoundScore || 0}</Score>
       </PlayerInfoBox>
       <ControlPanel />
       <GameStatusBar />

--- a/src/pages/select-model.tsx
+++ b/src/pages/select-model.tsx
@@ -40,11 +40,11 @@ export default function SelectRobot() {
     switch (modelType) {
       case RobotModelType.PROBE:
         return `둥둥이 로봇,\n화가 나면 복어처럼 부풀어올라요!`;
-      case RobotModelType.SMART_DRONE:
-        return `지상형 스파이더 로봇,\n화가 나면 무서운 표정으로 바뀌어요!`;
       case RobotModelType.PENGUIN:
-      default:
         return `펭귄 로봇,\n화가 나면 파닥거리면서 불이 나와요!`;
+      case RobotModelType.SMART_DRONE:
+      default:
+        return `지상형 스파이더 로봇,\n화가 나면 무서운 표정으로 바뀌어요!`;
     }
   };
 

--- a/src/pages/welcome-back.tsx
+++ b/src/pages/welcome-back.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable react/no-unknown-property */
+import { MouseEventHandler, useMemo } from "react";
 import Image from "next/image";
 import { useRouter } from "next/router";
+import axios from "axios";
 
 import Model from "@/components/organisms/Model";
+import useGameActions from "@/hooks/useGameActions";
+import useGameStatus from "@/hooks/useGameRound";
 import usePlayer from "@/hooks/usePlayer";
 import useUser from "@/hooks/useUser";
 import { ButtonShape, Page } from "@/types";
@@ -31,6 +35,53 @@ export default function WelcomeBack() {
   const router = useRouter();
   const user = useUser();
   const player = usePlayer();
+  const gameRound = useGameStatus();
+  const { assignPlayer, updateGameRound } = useGameActions();
+
+  const maxScore = useMemo(
+    () => ((player.allRoundScore ?? []).length ? Math.max(...player.allRoundScore) : 0),
+    [player.allRoundScore],
+  );
+
+  // 재-게임시 실행하게 되는 함수
+  const createCharacter: MouseEventHandler = (e) => {
+    e.preventDefault();
+
+    // 언리얼로 캐릭터 생성 요청 보내기
+    axios
+      .put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
+        objectPath: gameRound.gameModeBaseObjectPath,
+        functionName: "BindingCharacter",
+        parameters: {
+          Model: player.model,
+          Color: player.color,
+          Name: player.headTag,
+          UID: user.uid,
+        },
+        generateTransaction: true,
+      })
+      .then((res) => {
+        const createdCharacterInfo = res.data;
+        // 전역상태로 새로운 플레이어 정보 저장
+        // 새로운 라운드를 위해 점수는 0점으로 리셋
+        assignPlayer({
+          ...player,
+          uid: user.uid,
+          thisRoundScore: 0,
+          objectPath: createdCharacterInfo.CharacterPath,
+        });
+
+        // 현재 진행중인 게임 라운드의 남은 시간 업데이트
+        updateGameRound({
+          ...gameRound,
+          isGameInProgress: !!Number(createdCharacterInfo.MainGameRemainTime),
+          timeLeft: createdCharacterInfo.MainGameRemainTime,
+        });
+
+        // 로봇 커스텀 단계 생략하고 바로 게임 실행 화면으로 페이지 이동
+        router.push(Page.GOING_TO_HANGAR);
+      });
+  };
   return (
     <Container>
       <MainSection>
@@ -49,7 +100,7 @@ export default function WelcomeBack() {
           </Unit>
           <Unit>
             <HistoryName>최고점수</HistoryName>
-            <HistoryContext>{player.score}점</HistoryContext>
+            <HistoryContext>{maxScore}점</HistoryContext>
           </Unit>
         </GameHistory>
         <CanvasWrapper>
@@ -67,11 +118,7 @@ export default function WelcomeBack() {
       </MainSection>
       <ButtonWrapper>
         <ResetRobot onClick={() => router.push(Page.SELECT_MODEL)}>로봇 바꾸기</ResetRobot>
-        <PlayButton
-          type="button"
-          shape={ButtonShape.RECTANGLE}
-          onClick={() => router.push(Page.GOING_TO_HANGAR)}
-        >
+        <PlayButton type="button" shape={ButtonShape.RECTANGLE} onClick={createCharacter}>
           출동하기
         </PlayButton>
       </ButtonWrapper>

--- a/src/slices/game.ts
+++ b/src/slices/game.ts
@@ -9,7 +9,8 @@ export interface Player {
   headTag: string | undefined;
   model: RobotModelType | undefined;
   color: RobotColor | undefined;
-  score: number | undefined;
+  thisRoundScore: number | undefined;
+  allRoundScore: number[] | undefined;
   playedNum: number | undefined;
 }
 
@@ -31,7 +32,8 @@ const initialState: GameState = {
     headTag: undefined,
     model: undefined,
     color: undefined,
-    score: 0,
+    thisRoundScore: undefined,
+    allRoundScore: undefined,
     playedNum: undefined,
   },
   gameRound: {


### PR DESCRIPTION
## 업데이트
- 게임 진행 중 얻은 점수 실시간으로 업데이트, 화면에 표시 
- 게임 시간 및 휴식 시간 (결과 보여주는 시간) 끝나면 firebase 데이터베이스에 점수 업데이트하고, 화면에 표시하는 점수는 0점으로 리셋한 이후, 출동! 

![06-22-score-real-time](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/3713906a-ed7a-40b7-bdde-b98675e03990)
