### PR TITLE
feat: protect routes that needs authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ./{src,public}/**/*.{ts,jsx,tsx,json} ./global.d.ts",
-    "lint:fix": "eslint --fix ./{src,public}/**/*.{ts,jsx,tsx,json} ./global.d.ts",
-    "format": "prettier --write ./{src,public}/**/*.{ts,jsx,tsx,json} ./global.d.ts --config ./.prettierrc.json"
+    "lint": "eslint ./{src,public}/**/*.{ts,jsx,tsx,js,json} ./global.d.ts",
+    "lint:fix": "eslint --fix ./{src,public}/**/*.{ts,js,jsx,tsx,json} ./global.d.ts",
+    "format": "prettier --write ./{src,public}/**/*.{ts,js,jsx,tsx,json} ./global.d.ts --config ./.prettierrc.json"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",


### PR DESCRIPTION
### Updates
- 로그인하지 않은 사용자가 인증이 필요한 페이지에 접근하는 경우, `/` 경로로 리다이렉트 처리

### Preview
![06-28-redirect-to-home-when-approaching-to-auth-required-pages](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/7b2848a7-6caa-4bac-8c7d-8039ece73d17)
