### PR TITLE
fix: keep the app state after page reload or refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-toastify": "^9.1.3",
     "redux": "^4.2.1",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.4.2",
+    "redux-persist": "^6.0.0",
     "styled-reset": "^4.4.7",
     "three": "^0.153.0",
     "valtio": "^1.10.5"
@@ -46,6 +46,7 @@
     "@types/react-dom": "18.2.4",
     "@types/react-redux": "^7.1.25",
     "@types/redux-logger": "^3.0.9",
+    "@types/redux-persist": "^4.3.1",
     "@types/three": "^0.152.1",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.8",

--- a/src/components/molecules/Picker/index.tsx
+++ b/src/components/molecules/Picker/index.tsx
@@ -5,6 +5,7 @@ import BasicButton from "@/components/atoms/BasicButton";
 import { ColorPalette } from "@/components/organisms/Model/styles";
 import useGameActions from "@/hooks/useGameActions";
 import usePlayer from "@/hooks/usePlayer";
+import { Player } from "@/slices/game";
 import { ButtonShape, RobotColor, RobotModelType } from "@/types";
 
 export const modelColorState = proxy({
@@ -16,7 +17,7 @@ export const modelColorState = proxy({
 });
 
 interface Props {
-  modelType: RobotModelType;
+  modelType: RobotModelType | undefined;
 }
 
 export default function Picker({ modelType }: Props) {
@@ -38,7 +39,7 @@ export default function Picker({ modelType }: Props) {
       }
     })();
     assignPlayer({
-      ...player,
+      ...(player as Player),
       color: modelColor,
     });
     if (key) modelColorState.items[key] = modelColor;

--- a/src/components/molecules/SectionCard/index.tsx
+++ b/src/components/molecules/SectionCard/index.tsx
@@ -64,9 +64,9 @@ export default function SectionCard({ sectionNumber, selectedSection, setSelecte
       switch (sectionNumber) {
         case 3:
         default: {
-          if (!player.model) return Page.SELECT_MODEL;
-          else if (!player.color) return Page.CUSTOMIZE_DESIGN;
-          else if (!player.headTag) return Page.NAME_YOUR_ROBOT;
+          if (!player?.model) return Page.SELECT_MODEL;
+          else if (!player?.color) return Page.CUSTOMIZE_DESIGN;
+          else if (!player?.headTag) return Page.NAME_YOUR_ROBOT;
           else return Page.WELCOME_BACK;
         }
       }

--- a/src/components/organisms/ControlPanel/index.tsx
+++ b/src/components/organisms/ControlPanel/index.tsx
@@ -1,11 +1,13 @@
 import { MouseEvent, MouseEventHandler, useEffect, useState } from "react";
 import axios from "axios";
+import _ from "lodash";
 import { toast } from "react-toastify";
 
 import Arrow from "@/components/atoms/Arrow";
 import Fire from "@/components/atoms/Fire";
 import useGameActions from "@/hooks/useGameActions";
 import usePlayer from "@/hooks/usePlayer";
+import { Player } from "@/slices/game";
 import { ControlPanelEvent } from "@/types";
 
 import { FireButton, JumpButton, MoveLeftButton, MoveRightButton, Panel } from "./styles";
@@ -34,23 +36,32 @@ export default function ControlPanel() {
     timer = setInterval(callback, 10);
   };
 
-  const onJump: MouseEventHandler = async () =>
-    await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
-      objectPath: player.objectPath,
+  const onJump: MouseEventHandler = async () => {
+    if (_.isNil(player?.objectPath)) return;
+
+    return await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
+      objectPath: player?.objectPath,
       functionName: "OnJump",
     });
+  };
 
-  const onFire = async () =>
-    await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
-      objectPath: player.objectPath,
+  const onFire = async () => {
+    if (_.isNil(player?.objectPath)) return;
+
+    return await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
+      objectPath: player?.objectPath,
       functionName: "OnFire",
     });
+  };
 
-  const getScore = async () =>
-    await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
-      objectPath: player.objectPath,
+  const getScore = async () => {
+    if (_.isNil(player?.objectPath)) return;
+
+    return await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
+      objectPath: player?.objectPath,
       functionName: "GetPlayerScore",
     });
+  };
 
   const handleFire = (e: MouseEvent) => {
     e.preventDefault();
@@ -60,8 +71,9 @@ export default function ControlPanel() {
       // 0.5초 뒤에 점수 요청 및 전역 상태 업데이트
       setTimeout(() => {
         getScore().then((res) => {
+          if (_.isNil(res)) return;
           assignPlayer({
-            ...player,
+            ...(player as Player),
             thisRoundScore: res.data.PlayerScore,
           });
         });
@@ -71,8 +83,10 @@ export default function ControlPanel() {
 
   const moveLeft = async () => {
     try {
+      if (_.isNil(player?.objectPath)) return;
+
       await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
-        objectPath: player.objectPath,
+        objectPath: player?.objectPath,
         functionName: "SetMoveForwardLeft",
         generateTransaction: true,
       });
@@ -86,8 +100,10 @@ export default function ControlPanel() {
 
   const moveRight = async () => {
     try {
+      if (_.isNil(player?.objectPath)) return;
+
       await axios.put(`${process.env.NEXT_PUBLIC_UNREAL_DOMAIN}/remote/object/call`, {
-        objectPath: player.objectPath,
+        objectPath: player?.objectPath,
         functionName: "SetMoveForwardRight",
         generateTransaction: true,
       });

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -56,6 +56,15 @@ export default function Header() {
     }
   })();
 
+  const isVisible = (() => {
+    switch (router.asPath) {
+      case Page.HOME:
+        return false;
+      default:
+        return true;
+    }
+  })();
+
   const getPreviousPage = (() => {
     switch (router.asPath) {
       case Page.NAME_YOUR_ROBOT:
@@ -92,18 +101,18 @@ export default function Header() {
     }
   };
   return (
-    <Root showUserOnHeader={showUserOnHeader}>
+    <Root showUserOnHeader={showUserOnHeader} isVisible={isVisible}>
       <Inner isMobile={isMobile}>
         {showUserOnHeader ? (
           <ProfileBox>
-            {user.image ? (
+            {user?.image ? (
               <ProfileImageWrapper>
                 <Image width={47} height={47} src={user.image} alt={user.displayName} />
               </ProfileImageWrapper>
             ) : (
               <ProfileImage />
             )}
-            <UserName>{user.displayName}</UserName>
+            <UserName>{user?.displayName}</UserName>
           </ProfileBox>
         ) : (
           <ArrowBackIcon onClick={() => router.push(getPreviousPage)}>

--- a/src/components/organisms/Header/styles.ts
+++ b/src/components/organisms/Header/styles.ts
@@ -2,8 +2,9 @@ import ExitToAppRoundedIcon from "@mui/icons-material/ExitToAppRounded";
 import { styled } from "@mui/material/styles";
 
 export const Root = styled("header", {
-  shouldForwardProp: (props) => props !== "showUserOnHeader",
+  shouldForwardProp: (props) => props !== "isVisible" && props !== "showUserOnHeader",
 })<{
+  isVisible: boolean;
   showUserOnHeader: boolean;
 }>`
   position: fixed;
@@ -11,6 +12,7 @@ export const Root = styled("header", {
   width: 100%;
   height: ${({ showUserOnHeader }) => (showUserOnHeader ? "11.7vh" : "10.5vh")};
   z-index: 9;
+  visibility: ${({ isVisible }) => (isVisible ? "visible" : "hidden")};
 `;
 
 export const Inner = styled("div", {

--- a/src/components/organisms/Model/index.tsx
+++ b/src/components/organisms/Model/index.tsx
@@ -20,5 +20,5 @@ export default function Model() {
     }
   };
 
-  return <>{getModel(player?.model)}</>;
+  return <>{getModel(player?.model as RobotModelType)}</>;
 }

--- a/src/firebase/players.ts
+++ b/src/firebase/players.ts
@@ -23,7 +23,9 @@ interface Props {
   modelColor: RobotColor;
   modelType: RobotModelType;
   username: string;
-  score: number[]; // 지금까지 출동해서 받은 점수들의 배열
+  score: {
+    [key: string]: number;
+  }; // 지금까지 출동해서 받은 점수들의 배열
   playedNum: number;
 }
 
@@ -73,7 +75,9 @@ const updatePlayer = async ({
 }: {
   documentId: string;
   updated: {
-    score?: number[];
+    score?: {
+      [key: string]: number;
+    };
     playedNum?: number;
     gotFirstPlace?: number;
   };

--- a/src/pages/[clientId]/index.tsx
+++ b/src/pages/[clientId]/index.tsx
@@ -43,7 +43,6 @@ export default function HomePage() {
           const { uid, headTag, modelType, modelColor, score, playedNum, gotFirstPlace } = res[0];
 
           assignPlayer({
-            ...player,
             uid: uid,
             headTag,
             model: modelType,
@@ -51,6 +50,7 @@ export default function HomePage() {
             thisRoundScore: 0,
             allRoundScore: score ?? {},
             playedNum: playedNum ?? 0,
+            objectPath: player?.objectPath,
             gotFirstPlace: gotFirstPlace ?? 0,
           });
         }

--- a/src/pages/going-to-hangar.tsx
+++ b/src/pages/going-to-hangar.tsx
@@ -38,12 +38,13 @@ export default function GoingToHangar() {
         });
       });
     // firebase 데이터베이스에 출동횟수 + 1한 값으로 업데이트
-    updatePlayer({
-      documentId: player.uid,
-      updated: {
-        playedNum: player.playedNum ? player.playedNum + 1 : 1,
-      },
-    });
+    if (player.uid)
+      updatePlayer({
+        documentId: player.uid,
+        updated: {
+          playedNum: player.playedNum ? player.playedNum + 1 : 1,
+        },
+      });
     // 전역 상태에 출동회수 +1한 값으로 업데이트
     assignPlayer({
       ...player,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import useUser from "@/hooks/useUser";
 import { ButtonShape } from "@/types";
 
 import {
@@ -13,7 +12,6 @@ import {
 } from "@/styles/home.styles";
 
 export default function HomePage() {
-  const user = useUser();
   return (
     <Container>
       <MainSection>
@@ -25,7 +23,6 @@ export default function HomePage() {
       <ButtonWrapper>
         <StartButton
           type="button"
-          disabled={!!user}
           shape={ButtonShape.RECTANGLE}
           onClick={() => {
             (window as Window).location = process.env.NEXT_PUBLIC_FURO_OAUTH_CUSTOM_URL as string;

--- a/src/pages/name-your-robot.tsx
+++ b/src/pages/name-your-robot.tsx
@@ -2,6 +2,7 @@
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import { useRouter } from "next/router";
 import axios from "axios";
+import _ from "lodash";
 
 import BasicButton from "@/components/atoms/BasicButton";
 import BasicInput from "@/components/atoms/BasicInput";
@@ -12,7 +13,7 @@ import useGameActions from "@/hooks/useGameActions";
 import useGameStatus from "@/hooks/useGameRound";
 import usePlayer from "@/hooks/usePlayer";
 import useUser from "@/hooks/useUser";
-import { ButtonShape, Page } from "@/types";
+import { ButtonShape, Page, RobotColor, RobotModelType } from "@/types";
 import isProfane from "@/utils/isProfane";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
@@ -52,12 +53,12 @@ export default function NameYourRobot() {
       return;
     }
 
-    if (/[`~!@#$%^&*|\\'",;:/?]/gi.test(inputValue)) {
+    if (/[`~!@#$%^&*|\\'",;:/?]/gi.test(inputValue as string)) {
       setErrorMessage("문자 또는 숫자만 사용가능합니다");
       return;
     }
 
-    if (isProfane({ keyword: inputValue })) {
+    if (isProfane({ keyword: inputValue as string })) {
       setErrorMessage("비속어를 포함하고 있습니다");
       return;
     }
@@ -70,10 +71,10 @@ export default function NameYourRobot() {
         objectPath: gameRound.gameModeBaseObjectPath,
         functionName: "BindingCharacter",
         parameters: {
-          Model: player.model,
-          Color: player.color,
+          Model: player?.model,
+          Color: player?.color,
           Name: inputValue,
-          UID: user.uid,
+          UID: user?.uid,
         },
         generateTransaction: true,
       })
@@ -81,12 +82,13 @@ export default function NameYourRobot() {
         const createdCharacterInfo = res.data;
         if (createdCharacterInfo) {
           // firebase 데이터베이스에 새로운 플레이어 생성 요청
+          if (_.isNil(user) || _.isNil(player)) return;
           createPlayer({
-            uid: user.uid,
+            uid: user?.uid,
             profileUrl: user.image,
-            headTag: inputValue,
-            modelColor: player.color,
-            modelType: player.model,
+            headTag: inputValue as string,
+            modelColor: player.color as RobotColor,
+            modelType: player.model as RobotModelType,
             username: user.displayName,
             score: player.allRoundScore ?? {},
             playedNum: player.playedNum ?? 0,
@@ -136,7 +138,7 @@ export default function NameYourRobot() {
         <StyledForm noValidate onSubmit={createCharacter}>
           <InputWrapper>
             <BasicInput
-              value={inputValue}
+              value={inputValue as string}
               error={!!errorMessage}
               onChange={handleChange}
               onFocus={() => setErrorMessage("")}

--- a/src/pages/play.tsx
+++ b/src/pages/play.tsx
@@ -21,8 +21,8 @@ export default function PlayGame() {
             height={17}
           />
         ))}
-        <PlayerName>{player.headTag}</PlayerName>
-        <Score>{player.thisRoundScore || 0}</Score>
+        <PlayerName>{player?.headTag}</PlayerName>
+        <Score>{player?.thisRoundScore || 0}</Score>
       </PlayerInfoBox>
       <ControlPanel />
       <GameStatusBar />

--- a/src/pages/select-model.tsx
+++ b/src/pages/select-model.tsx
@@ -7,6 +7,7 @@ import Model from "@/components/organisms/Model";
 import useGameActions from "@/hooks/useGameActions";
 import usePlayer from "@/hooks/usePlayer";
 import useUser from "@/hooks/useUser";
+import { Player } from "@/slices/game";
 import { ButtonShape, Page, RobotModelType } from "@/types";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
@@ -31,12 +32,13 @@ export default function SelectRobot() {
 
   const selectModel = (modelType: RobotModelType) => {
     assignPlayer({
-      ...player,
+      ...(player as Player),
       model: modelType,
     });
   };
 
   const getDescription = (modelType: RobotModelType) => {
+    if (modelType === undefined) return;
     switch (modelType) {
       case RobotModelType.PROBE:
         return `둥둥이 로봇,\n화가 나면 복어처럼 부풀어올라요!`;
@@ -50,7 +52,7 @@ export default function SelectRobot() {
 
   useEffect(() => {
     assignPlayer({
-      ...player,
+      ...(player as Player),
       color: undefined,
     });
   }, []);
@@ -72,20 +74,20 @@ export default function SelectRobot() {
             />
           </Canvas>
         </CanvasWrapper>
-        <RobotDescription>{getDescription(player.model)}</RobotDescription>
+        <RobotDescription>{getDescription(player?.model as RobotModelType)}</RobotDescription>
       </MainSection>
       <OptionBox>
         <Option
           type="button"
           onClick={() => selectModel(RobotModelType.PENGUIN)}
-          isSelected={player.model === RobotModelType.PENGUIN}
+          isSelected={player?.model === RobotModelType.PENGUIN}
         >
           <Image width={77} height={77} src="/assets/images/models/penguin.svg" alt="penguin" />
         </Option>
         <Option
           type="button"
           onClick={() => selectModel(RobotModelType.SMART_DRONE)}
-          isSelected={player.model === RobotModelType.SMART_DRONE}
+          isSelected={player?.model === RobotModelType.SMART_DRONE}
         >
           <Image
             width={77}
@@ -97,7 +99,7 @@ export default function SelectRobot() {
         <Option
           type="button"
           onClick={() => selectModel(RobotModelType.PROBE)}
-          isSelected={player.model === RobotModelType.PROBE}
+          isSelected={player?.model === RobotModelType.PROBE}
         >
           <Image width={77} height={77} src="/assets/images/models/probe.svg" alt="probe" />
         </Option>

--- a/src/pages/welcome-back.tsx
+++ b/src/pages/welcome-back.tsx
@@ -9,6 +9,7 @@ import useGameActions from "@/hooks/useGameActions";
 import useGameStatus from "@/hooks/useGameRound";
 import usePlayer from "@/hooks/usePlayer";
 import useUser from "@/hooks/useUser";
+import { Player } from "@/slices/game";
 import { ButtonShape, Page } from "@/types";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
@@ -42,10 +43,10 @@ export default function WelcomeBack() {
 
   const maxScore = useMemo(
     () =>
-      Object.values(player.allRoundScore ?? {}).length
-        ? Math.max(...Object.values(player.allRoundScore).map((elem) => Number(elem)))
+      Object.values(player?.allRoundScore ?? {}).length
+        ? Math.max(...Object.values(player?.allRoundScore ?? {}).map((elem) => Number(elem)))
         : 0,
-    [player.allRoundScore],
+    [player?.allRoundScore],
   );
 
   // 재-게임시 실행하게 되는 함수
@@ -59,10 +60,10 @@ export default function WelcomeBack() {
         objectPath: gameRound.gameModeBaseObjectPath,
         functionName: "BindingCharacter",
         parameters: {
-          Model: player.model,
-          Color: player.color,
-          Name: player.headTag,
-          UID: user.uid,
+          Model: player?.model,
+          Color: player?.color,
+          Name: player?.headTag,
+          UID: user?.uid,
         },
         generateTransaction: true,
       })
@@ -71,8 +72,8 @@ export default function WelcomeBack() {
         // 전역상태로 새로운 플레이어 정보 저장
         // 새로운 라운드를 위해 점수는 0점으로 리셋
         assignPlayer({
-          ...player,
-          uid: user.uid,
+          ...(player as Player),
+          uid: user?.uid,
           thisRoundScore: 0,
           objectPath: createdCharacterInfo.CharacterPath,
         });
@@ -99,7 +100,7 @@ export default function WelcomeBack() {
         <GameHistory>
           <Unit>
             <HistoryName>출동수</HistoryName>
-            <HistoryContext>{player.playedNum}회</HistoryContext>
+            <HistoryContext>{player?.playedNum}회</HistoryContext>
           </Unit>
           <Unit>
             <HistoryName>전체랭킹</HistoryName>
@@ -124,7 +125,7 @@ export default function WelcomeBack() {
             />
           </Canvas>
           <StarBox>
-            {Array.from(Array(player.gotFirstPlace)).map((_, index) => (
+            {Array.from(Array(player?.gotFirstPlace)).map((_, index) => (
               <Image
                 key={`star-${index}`}
                 src="/assets/images/star.svg"
@@ -135,7 +136,7 @@ export default function WelcomeBack() {
             ))}
           </StarBox>
         </CanvasWrapper>
-        <RobotName>{player.headTag}</RobotName>
+        <RobotName>{player?.headTag}</RobotName>
       </MainSection>
       <ButtonWrapper>
         <ResetRobot onClick={() => router.push(Page.SELECT_MODEL)}>로봇 바꾸기</ResetRobot>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,13 @@
   dependencies:
     redux "^4.0.0"
 
+"@types/redux-persist@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/redux-persist/-/redux-persist-4.3.1.tgz#aa4c876859e0bea5155e5f7980e5b8c4699dc2e6"
+  integrity sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==
+  dependencies:
+    redux-persist "*"
+
 "@types/scheduler@*":
   version "0.16.3"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
@@ -3539,6 +3546,11 @@ redux-logger@^3.0.6:
   integrity sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==
   dependencies:
     deep-diff "^0.3.5"
+
+redux-persist@*, redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
 redux-thunk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
### 업데이트
- 페이지 새로고침을 했을 때, 사용자의 로그인 상태가 유지되지 않는 것을 확인하여 `redux-persist` 를 이용해 `localStorage`로도 상태 관리가 되도록 개선하였음

![image](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/c440b0fd-dde7-417c-88aa-ff0209098621)

- 개발자도구 콘솔창에 상태 변화 로그가 남도록 `redux-logger`를 활용함 
![image](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/ce5be372-2caf-45d8-9c52-a451d1a75c24)

- 전역 상태에 대한 type 적용을 보다 엄격히 하였음