### PR TITLE
fix: send error code if there's no error response status

### DIFF
--- a/src/components/organisms/ControlPanel/index.tsx
+++ b/src/components/organisms/ControlPanel/index.tsx
@@ -44,8 +44,10 @@ export default function ControlPanel() {
       .catch((error) => {
         const notice = {
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"OnJump" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"OnJump" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,
@@ -82,8 +84,10 @@ export default function ControlPanel() {
       .catch((error) => {
         const notice = {
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"OnFire" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"OnFire" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,
@@ -107,8 +111,10 @@ export default function ControlPanel() {
       .catch((error) => {
         const notice = {
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"GetPlayerScore" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"GetPlayerScore" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,
@@ -166,8 +172,10 @@ export default function ControlPanel() {
     } catch (error: any) {
       const notice = {
         errorName: error.name,
-        errorCode: error.response?.status,
-        errorMessage: `"SetMoveForwardLeft" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+        errorCode: error.response?.status || error.code,
+        errorMessage: `"SetMoveForwardLeft" 함수에서 다음 에러 발생: ${
+          error?.message || error.response?.data.errorMessage
+        }`,
       };
       noticeToSlack({
         ...notice,
@@ -208,8 +216,10 @@ export default function ControlPanel() {
     } catch (error: any) {
       const notice = {
         errorName: error.name,
-        errorCode: error.response?.status,
-        errorMessage: `"SetMoveForwardRight" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+        errorCode: error.response?.status || error.code,
+        errorMessage: `"SetMoveForwardRight" 함수에서 다음 에러 발생: ${
+          error?.message || error.response?.data.errorMessage
+        }`,
       };
       noticeToSlack({
         ...notice,

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -105,8 +105,10 @@ export default function Header() {
           const notice = {
             isUrgent: true,
             errorName: error.name,
-            errorCode: error.response?.status,
-            errorMessage: `"SetPlayerDefaultLocation" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+            errorCode: error.response?.status || error.code,
+            errorMessage: `"SetPlayerDefaultLocation" 함수에서 다음 에러 발생: ${
+              error?.message || error.response?.data.errorMessage
+            }`,
           };
           noticeToSlack({
             ...notice,

--- a/src/components/organisms/Timer/index.tsx
+++ b/src/components/organisms/Timer/index.tsx
@@ -163,8 +163,10 @@ export default function Countdown() {
       .catch((error) => {
         const notice = {
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"GetCurrentRoundBestOfPlayer" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"GetCurrentRoundBestOfPlayer" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -56,8 +56,10 @@ function MyApp(props: MyAppProps) {
         const notice = {
           isUrgent: true,
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"GameModeBaseObjPath" 프로퍼티를 호출하는 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"GameModeBaseObjPath" 프로퍼티를 호출하는 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,

--- a/src/pages/going-to-hangar.tsx
+++ b/src/pages/going-to-hangar.tsx
@@ -42,8 +42,10 @@ export default function GoingToHangar() {
       .catch((error) => {
         const notice = {
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"GetCurrentRoundName" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"GetCurrentRoundName" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,

--- a/src/pages/name-your-robot.tsx
+++ b/src/pages/name-your-robot.tsx
@@ -131,8 +131,10 @@ export default function NameYourRobot() {
         const notice = {
           isUrgent: true,
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"BindingCharacter" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"BindingCharacter" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,

--- a/src/pages/welcome-back.tsx
+++ b/src/pages/welcome-back.tsx
@@ -118,8 +118,10 @@ export default function WelcomeBack() {
         const notice = {
           isUrgent: true,
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"BindingCharacter" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"BindingCharacter" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,
@@ -152,8 +154,10 @@ export default function WelcomeBack() {
       .catch((error) => {
         const notice = {
           errorName: error.name,
-          errorCode: error.response?.status,
-          errorMessage: `"GetGameRanking" 함수에서 다음 에러 발생: ${error.response?.data.errorMessage}`,
+          errorCode: error.response?.status || error.code,
+          errorMessage: `"GetGameRanking" 함수에서 다음 에러 발생: ${
+            error?.message || error.response?.data.errorMessage
+          }`,
         };
         noticeToSlack({
           ...notice,


### PR DESCRIPTION
### 업데이트
- 네트워크 에러가 발생하는 경우 에러메시지 및 상태코드가 `undefined`로 swit 및 slack에 전송되었음(아래 스크린샷 참조)
![image](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/b32a8ee2-968c-4e75-a1d6-8debc78776c2)
- 본 PR에서의 변경사항으로 다음과 같이 네트워크 오류 에러메시지 수정
![image](https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/81a5af44-bfa8-4210-87d9-a59c7612fbce)
 