### PR TITLE
fix: add condition to activate the game status bar

### DIFF
--- a/src/components/molecules/GameStatusBar/index.tsx
+++ b/src/components/molecules/GameStatusBar/index.tsx
@@ -1,12 +1,12 @@
 import useGameStatus from "@/hooks/useGameRound";
+import { TimeSchedule } from "@/types";
 
 import { StatusBar } from "./styles";
 
 export default function GameStatusBar() {
-  const { isGameInProgress } = useGameStatus();
+  const { isGameInProgress, currentTimeSchedule } = useGameStatus();
+  const isActive = isGameInProgress && currentTimeSchedule === TimeSchedule.GAMING;
   return (
-    <StatusBar isActive={isGameInProgress}>
-      {isGameInProgress ? "미션수행중" : "곧 미션이 시작됩니다!"}
-    </StatusBar>
+    <StatusBar isActive={isActive}>{isActive ? "미션수행중" : "곧 미션이 시작됩니다!"}</StatusBar>
   );
 }


### PR DESCRIPTION
### 업데이트
- `/play` 페이지에서 오로지 게임진행중일 때에만 하단 상태바가 활성화되도록 버그 수정

### 프리뷰
<table>
<tr>
    <th>버그 수정 전</th>
    <th>버그 수정 후</th>
  </tr>
<tr>
    <td> /play 페이지에 랜딩했을 때, 하단 상태바가 찰나 게임진행중으로 잘못 나타남</td>
    <td>실제로 게임진행중일 때에만 상태바가 활성화됨</td>
  </tr>
  <tr>
    <td>
<img src="https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/557c7ece-ea38-4d5c-9371-04dbcf68d15c"  alt="1" width = 150px  />
</td>
    <td>
<img src="https://github.com/CUZ-Studio/remote-control-demo-app/assets/61447729/33ba91be-1dd2-4841-8ba3-377706845301"  alt="1" width = 150px  />
</td>
  </tr>
</table>